### PR TITLE
refactor: Move mod tracking lists into ModManager.

### DIFF
--- a/Source/Server/Core/Program.cs
+++ b/Source/Server/Core/Program.cs
@@ -23,10 +23,6 @@ namespace RimworldTogether.GameServer.Core
         public static string optionalModsPath;
         public static string forbiddenModsPath;
 
-        public static List<string> loadedRequiredMods = new List<string>();
-        public static List<string> loadedOptionalMods = new List<string>();
-        public static List<string> loadedForbiddenMods = new List<string>();
-
         public static ServerConfigFile serverConfig;
         public static ServerValuesFile serverValues;
         public static WorldValuesFile worldValues;

--- a/Source/Server/Managers/ModManager.cs
+++ b/Source/Server/Managers/ModManager.cs
@@ -7,9 +7,17 @@ namespace RimworldTogether.GameServer.Managers
 {
     public static class ModManager
     {
+        private static List<string> loadedRequiredMods = new List<string>();
+        private static List<string> loadedOptionalMods = new List<string>();
+        private static List<string> loadedForbiddenMods = new List<string>();
+
+        public static IReadOnlyCollection<string> LoadedRequiredMods => loadedRequiredMods;
+        public static IReadOnlyCollection<string> LoadedOptionalMods => loadedOptionalMods;
+        public static IReadOnlyCollection<string> LoadedForbiddenMods => loadedForbiddenMods;
+
         public static void LoadMods()
         {
-            Program.loadedRequiredMods.Clear();
+            loadedRequiredMods.Clear();
             string[] requiredModsToLoad = Directory.GetDirectories(Program.requiredModsPath);
             foreach (string modPath in requiredModsToLoad)
             {
@@ -18,15 +26,15 @@ namespace RimworldTogether.GameServer.Managers
                     string aboutFile = Directory.GetFiles(modPath, "About.xml", SearchOption.AllDirectories)[0];
                     foreach (string str in XmlParser.ParseDataFromXML(aboutFile, "packageId"))
                     {
-                        if (!Program.loadedRequiredMods.Contains(str.ToLower())) Program.loadedRequiredMods.Add(str.ToLower());
+                        if (!loadedRequiredMods.Contains(str.ToLower())) loadedRequiredMods.Add(str.ToLower());
                     }
                 }
                 catch { Logger.WriteToConsole($"[Error] > Failed to load About.xml of mod at '{modPath}'", Logger.LogMode.Error); }
             }
 
-            Logger.WriteToConsole($"Loaded required mods [{Program.loadedRequiredMods.Count()}]");
+            Logger.WriteToConsole($"Loaded required mods [{loadedRequiredMods.Count()}]");
 
-            Program.loadedOptionalMods.Clear();
+            loadedOptionalMods.Clear();
             string[] optionalModsToLoad = Directory.GetDirectories(Program.optionalModsPath);
             foreach (string modPath in optionalModsToLoad)
             {
@@ -35,15 +43,15 @@ namespace RimworldTogether.GameServer.Managers
                     string aboutFile = Directory.GetFiles(modPath, "About.xml", SearchOption.AllDirectories)[0];
                     foreach (string str in XmlParser.ParseDataFromXML(aboutFile, "packageId"))
                     {
-                        if (!Program.loadedOptionalMods.Contains(str.ToLower())) Program.loadedOptionalMods.Add(str.ToLower());
+                        if (!loadedOptionalMods.Contains(str.ToLower())) loadedOptionalMods.Add(str.ToLower());
                     }
                 }
                 catch { Logger.WriteToConsole($"[Error] > Failed to load About.xml of mod at '{modPath}'", Logger.LogMode.Error); }
             }
 
-            Logger.WriteToConsole($"Loaded optional mods [{Program.loadedOptionalMods.Count()}]");
+            Logger.WriteToConsole($"Loaded optional mods [{loadedOptionalMods.Count()}]");
 
-            Program.loadedForbiddenMods.Clear();
+            loadedForbiddenMods.Clear();
             string[] forbiddenModsToLoad = Directory.GetDirectories(Program.forbiddenModsPath);
             foreach (string modPath in forbiddenModsToLoad)
             {
@@ -52,22 +60,22 @@ namespace RimworldTogether.GameServer.Managers
                     string aboutFile = Directory.GetFiles(modPath, "About.xml", SearchOption.AllDirectories)[0];
                     foreach (string str in XmlParser.ParseDataFromXML(aboutFile, "packageId"))
                     {
-                        if (!Program.loadedForbiddenMods.Contains(str.ToLower())) Program.loadedForbiddenMods.Add(str.ToLower());
+                        if (!loadedForbiddenMods.Contains(str.ToLower())) loadedForbiddenMods.Add(str.ToLower());
                     }
                 }
                 catch { Logger.WriteToConsole($"[Error] > Failed to load About.xml of mod at '{modPath}'", Logger.LogMode.Error); }
             }
 
-            Logger.WriteToConsole($"Loaded forbidden mods [{Program.loadedForbiddenMods.Count()}]");
+            Logger.WriteToConsole($"Loaded forbidden mods [{loadedForbiddenMods.Count()}]");
         }
 
         public static bool CheckIfModConflict(Client client, LoginDetailsJSON loginDetailsJSON)
         {
             List<string> conflictingMods = new List<string>();
 
-            if (Program.loadedRequiredMods.Count() > 0)
+            if (loadedRequiredMods.Count() > 0)
             {
-                foreach (string mod in Program.loadedRequiredMods)
+                foreach (string mod in loadedRequiredMods)
                 {
                     if (!loginDetailsJSON.runningMods.Contains(mod))
                     {
@@ -78,7 +86,7 @@ namespace RimworldTogether.GameServer.Managers
 
                 foreach (string mod in loginDetailsJSON.runningMods)
                 {
-                    if (!Program.loadedRequiredMods.Contains(mod) && !Program.loadedOptionalMods.Contains(mod))
+                    if (!loadedRequiredMods.Contains(mod) && !loadedOptionalMods.Contains(mod))
                     {
                         conflictingMods.Add($"[Disallowed] > {mod}");
                         continue;
@@ -86,9 +94,9 @@ namespace RimworldTogether.GameServer.Managers
                 }
             }
 
-            if (Program.loadedForbiddenMods.Count() > 0)
+            if (loadedForbiddenMods.Count() > 0)
             {
-                foreach (string mod in Program.loadedForbiddenMods)
+                foreach (string mod in loadedForbiddenMods)
                 {
                     if (loginDetailsJSON.runningMods.Contains(mod))
                     {
@@ -105,7 +113,7 @@ namespace RimworldTogether.GameServer.Managers
 
             else
             {
-                if(client.isAdmin)
+                if (client.isAdmin)
                 {
                     Logger.WriteToConsole($"[Mod bypass] > {client.username}", Logger.LogMode.Warning);
                     client.runningMods = loginDetailsJSON.runningMods;

--- a/Source/Server/Managers/ServerCommandManager.cs
+++ b/Source/Server/Managers/ServerCommandManager.cs
@@ -3,10 +3,7 @@ using RimworldTogether.GameServer.Core;
 using RimworldTogether.GameServer.Files;
 using RimworldTogether.GameServer.Misc;
 using RimworldTogether.GameServer.Network;
-using RimworldTogether.Shared.JSON;
 using RimworldTogether.Shared.Misc;
-using RimworldTogether.Shared.Network;
-using System.Linq.Expressions;
 
 namespace RimworldTogether.GameServer.Managers
 {
@@ -49,7 +46,7 @@ namespace RimworldTogether.GameServer.Managers
                     {
                         if (commandToFetch.commandAction != null) commandToFetch.commandAction.Invoke();
 
-                        else Logger.WriteToConsole($"[ERROR] > Command '{commandToFetch.prefix}' didn't have any action built in", 
+                        else Logger.WriteToConsole($"[ERROR] > Command '{commandToFetch.prefix}' didn't have any action built in",
                             Logger.LogMode.Warning);
                     }
                 }
@@ -268,7 +265,7 @@ namespace RimworldTogether.GameServer.Managers
         private static void OpCommandAction()
         {
             Client toFind = Network.Network.connectedClients.ToList().Find(x => x.username == ServerCommandManager.commandParameters[0]);
-            if (toFind == null) Logger.WriteToConsole($"[ERROR] > User '{ServerCommandManager.commandParameters[0]}' was not found", 
+            if (toFind == null) Logger.WriteToConsole($"[ERROR] > User '{ServerCommandManager.commandParameters[0]}' was not found",
                 Logger.LogMode.Warning);
 
             else
@@ -305,7 +302,7 @@ namespace RimworldTogether.GameServer.Managers
         private static void DeopCommandAction()
         {
             Client toFind = Network.Network.connectedClients.ToList().Find(x => x.username == ServerCommandManager.commandParameters[0]);
-            if (toFind == null) Logger.WriteToConsole($"[ERROR] > User '{ServerCommandManager.commandParameters[0]}' was not found", 
+            if (toFind == null) Logger.WriteToConsole($"[ERROR] > User '{ServerCommandManager.commandParameters[0]}' was not found",
                 Logger.LogMode.Warning);
 
             else
@@ -456,25 +453,25 @@ namespace RimworldTogether.GameServer.Managers
 
         private static void ModListCommandAction()
         {
-            Logger.WriteToConsole($"Required Mods: [{Program.loadedRequiredMods.Count()}]", Logger.LogMode.Title, false);
+            Logger.WriteToConsole($"Required Mods: [{ModManager.LoadedRequiredMods.Count()}]", Logger.LogMode.Title, false);
             Logger.WriteToConsole("----------------------------------------", Logger.LogMode.Title, false);
-            foreach (string str in Program.loadedRequiredMods)
+            foreach (string str in ModManager.LoadedRequiredMods)
             {
                 Logger.WriteToConsole($"{str}", Logger.LogMode.Warning, writeToLogs: false);
             }
             Logger.WriteToConsole("----------------------------------------", Logger.LogMode.Title, false);
 
-            Logger.WriteToConsole($"Optional Mods: [{Program.loadedOptionalMods.Count()}]", Logger.LogMode.Title, false);
+            Logger.WriteToConsole($"Optional Mods: [{ModManager.LoadedOptionalMods.Count()}]", Logger.LogMode.Title, false);
             Logger.WriteToConsole("----------------------------------------", Logger.LogMode.Title, false);
-            foreach (string str in Program.loadedOptionalMods)
+            foreach (string str in ModManager.LoadedOptionalMods)
             {
                 Logger.WriteToConsole($"{str}", Logger.LogMode.Warning, writeToLogs: false);
             }
             Logger.WriteToConsole("----------------------------------------", Logger.LogMode.Title, false);
 
-            Logger.WriteToConsole($"Forbidden Mods: [{Program.loadedForbiddenMods.Count()}]", Logger.LogMode.Title, false);
+            Logger.WriteToConsole($"Forbidden Mods: [{ModManager.LoadedForbiddenMods.Count()}]", Logger.LogMode.Title, false);
             Logger.WriteToConsole("----------------------------------------", Logger.LogMode.Title, false);
-            foreach (string str in Program.loadedForbiddenMods)
+            foreach (string str in ModManager.LoadedForbiddenMods)
             {
                 Logger.WriteToConsole($"{str}", Logger.LogMode.Warning, writeToLogs: false);
             }
@@ -489,13 +486,13 @@ namespace RimworldTogether.GameServer.Managers
 
             else
             {
-                for(int i = 0; i < ServerCommandManager.eventTypes.Count(); i++)
+                for (int i = 0; i < ServerCommandManager.eventTypes.Count(); i++)
                 {
                     if (ServerCommandManager.eventTypes[i] == ServerCommandManager.commandParameters[1])
                     {
                         CommandManager.SendEventCommand(toFind, i);
 
-                        Logger.WriteToConsole($"Sent event '{ServerCommandManager.commandParameters[1]}' to {toFind.username}", 
+                        Logger.WriteToConsole($"Sent event '{ServerCommandManager.commandParameters[1]}' to {toFind.username}",
                             Logger.LogMode.Warning);
 
                         return;
@@ -504,7 +501,7 @@ namespace RimworldTogether.GameServer.Managers
 
                 Logger.WriteToConsole($"[ERROR] > Event '{ServerCommandManager.commandParameters[1]}' was not found",
                     Logger.LogMode.Warning);
-            }   
+            }
         }
 
         private static void EventAllCommandAction()
@@ -543,7 +540,7 @@ namespace RimworldTogether.GameServer.Managers
         private static void BroadcastCommandAction()
         {
             string fullText = "";
-            foreach(string str in ServerCommandManager.commandParameters)
+            foreach (string str in ServerCommandManager.commandParameters)
             {
                 fullText += $"{str} ";
             }


### PR DESCRIPTION
This PR moves the mod tracking lists into the static ModManager class, provides readonly access to those via get-only properties, and updates the small number of places accessing them outside the manager.